### PR TITLE
Reservation list endpoint with filtering of active, passed and cancelled reservations

### DIFF
--- a/src/main/java/pw/react/backend/controller/ReservationController.kt
+++ b/src/main/java/pw/react/backend/controller/ReservationController.kt
@@ -83,14 +83,14 @@ class ReservationController(
     fun getReservations(
         @RequestParam page: Int,
         @RequestParam pageSize: Int,
-        @RequestParam reservationStatus: String?,
+        @RequestParam filter: String?,
         request: HttpServletRequest
     ): ResponseEntity<*> = try {
         val token = request.getHeader(HttpHeaders.AUTHORIZATION).substringAfter(BEARER)
         val email = jwtTokenService.getUsernameFromToken(token)
         val userId = userService.findUserByEmail(email)?.id
             ?: throw UsernameNotFoundException("user with email: $email not found")
-        val filter = when (reservationStatus?.lowercase()) {
+        val reservationFilter = when (filter?.lowercase()) {
             null -> ReservationFilter.All
             "all" -> ReservationFilter.All
             "active" -> ReservationFilter.Active
@@ -98,7 +98,7 @@ class ReservationController(
             "cancelled" -> ReservationFilter.Cancelled
             else -> throw IllegalArgumentException("Invalid reservationStatus. Possible values are: all, active, passed or cancelled")
         }
-        val reservationPage = reservationService.getReservations(userId, page, pageSize, filter)
+        val reservationPage = reservationService.getReservations(userId, page, pageSize, reservationFilter)
         val reservationsPageDto: PageDto<List<UserReservationDto>> = reservationPage.toDto { reservation ->
             with(reservation) {
                 val flat = flatService.findById(flatId)

--- a/src/main/java/pw/react/backend/controller/ReservationController.kt
+++ b/src/main/java/pw/react/backend/controller/ReservationController.kt
@@ -2,6 +2,7 @@ package pw.react.backend.controller
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import jakarta.servlet.http.HttpServletRequest
@@ -79,6 +80,31 @@ class ReservationController(
         ResponseEntity.unprocessableEntity().body(e.message)
     }
 
+    @Operation(
+        summary = "Get reservations",
+        description = "`filter` is optional. Possible values are: all, active, passed, cancelled. " +
+                "If the `filter` is not provided then endpoint returns all user's reservations. "
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successfully got reservation list. Note that `UserReservationDto` is encapsulated in `PageDto` " +
+                "which has `data` - list of UserReservationDto and `last` field indicating whether the page was last or not",
+        content = [
+            Content(mediaType = "application/json", schema = Schema(oneOf = [UserReservationDto::class]))
+        ]
+    )
+    @ApiResponse(
+        responseCode = "400",
+        description = "page or pageSize number was illegal or provided filter was not correct"
+    )
+    @ApiResponse(
+        responseCode = "404",
+        description = "User from jwt token was not found."
+    )
+    @ApiResponse(
+        responseCode = "422",
+        description = "Reserved flat was not found"
+    )
     @GetMapping("/reservations")
     fun getReservations(
         @RequestParam page: Int,

--- a/src/main/java/pw/react/backend/controller/ReservationController.kt
+++ b/src/main/java/pw/react/backend/controller/ReservationController.kt
@@ -8,20 +8,29 @@ import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import pw.react.backend.exceptions.FlatNotFoundException
 import pw.react.backend.exceptions.ReservationException
 import pw.react.backend.security.jwt.services.JwtTokenService
+import pw.react.backend.services.FlatPriceService
+import pw.react.backend.services.FlatService
 import pw.react.backend.services.ReservationService
 import pw.react.backend.services.UserService
+import pw.react.backend.web.PageDto
 import pw.react.backend.web.ReservationDto
+import pw.react.backend.web.UserReservationDto
 import pw.react.backend.web.toDomain
 import pw.react.backend.web.toDto
 
 @RestController
 class ReservationController(
+    private val flatService: FlatService,
     private val reservationService: ReservationService,
+    private val flatPriceService: FlatPriceService,
     private val jwtTokenService: JwtTokenService,
     private val userService: UserService,
 ) {
@@ -66,6 +75,42 @@ class ReservationController(
     } catch (e: IllegalArgumentException) {
         ResponseEntity.badRequest().body(e.message)
     } catch (e: ReservationException) {
+        ResponseEntity.unprocessableEntity().body(e.message)
+    }
+
+    @GetMapping("/reservations")
+    fun getReservations(
+        @RequestParam page: Int,
+        @RequestParam pageSize: Int,
+        request: HttpServletRequest
+    ): ResponseEntity<*> = try {
+        val token = request.getHeader(HttpHeaders.AUTHORIZATION).substringAfter(BEARER)
+        val email = jwtTokenService.getUsernameFromToken(token)
+        val userId = userService.findUserByEmail(email)?.id
+            ?: throw UsernameNotFoundException("user with email: $email not found")
+        val reservationPage = reservationService.getReservations(userId, page, pageSize)
+        val reservationsPageDto: PageDto<List<UserReservationDto>> = reservationPage.toDto { reservation ->
+            with(reservation) {
+                val flat = flatService.findById(flatId)
+                    ?: throw FlatNotFoundException("flat with id: $flatId was not found")
+                val price = flatPriceService.getPriceByFlatId(flatId, startDate, endDate)
+                UserReservationDto(
+                    flatId = flatId,
+                    reservationId = id!!,
+                    title = flat.title,
+                    thumbnailUrl = flat.thumbnailUrl,
+                    city = flat.address.city,
+                    country = flat.address.country,
+                    startDate = startDate.toString(),
+                    endDate = endDate.toString(),
+                    totalPrice = price
+                )
+            }
+        }
+        ResponseEntity.ok().body(reservationsPageDto)
+    } catch (e: IllegalArgumentException) {
+        ResponseEntity.badRequest().body(e.message)
+    } catch (e: FlatNotFoundException) {
         ResponseEntity.unprocessableEntity().body(e.message)
     }
 

--- a/src/main/java/pw/react/backend/controller/ReservationController.kt
+++ b/src/main/java/pw/react/backend/controller/ReservationController.kt
@@ -148,6 +148,8 @@ class ReservationController(
         ResponseEntity.badRequest().body(e.message)
     } catch (e: FlatNotFoundException) {
         ResponseEntity.unprocessableEntity().body(e.message)
+    } catch (e: UsernameNotFoundException) {
+        ResponseEntity.notFound().build<Void>()
     }
 
     companion object {

--- a/src/main/java/pw/react/backend/dao/ReservationRepository.kt
+++ b/src/main/java/pw/react/backend/dao/ReservationRepository.kt
@@ -20,4 +20,20 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
     fun countAllWithOverlappingDates(flatId: String, start: LocalDate, end: LocalDate): Int
 
     fun findAllByUserId(userId: Long, pageable: Pageable): Page<ReservationEntity>
+
+    @Query(
+        value = """
+            select reservation from ReservationEntity reservation 
+            where reservation.user.id = ?1 and reservation.endDate >= ?2
+        """
+    )
+    fun findAllActiveByUserId(userId: Long, today: LocalDate, pageable: Pageable): Page<ReservationEntity>
+
+    @Query(
+        value = """
+            select reservation from ReservationEntity reservation
+            where reservation.user.id = ?1 and reservation.endDate < ?2
+        """
+    )
+    fun findAllPassedByUserId(userId: Long, today: LocalDate, pageable: Pageable): Page<ReservationEntity>
 }

--- a/src/main/java/pw/react/backend/dao/ReservationRepository.kt
+++ b/src/main/java/pw/react/backend/dao/ReservationRepository.kt
@@ -1,5 +1,7 @@
 package pw.react.backend.dao
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import pw.react.backend.models.entity.ReservationEntity
@@ -16,4 +18,6 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
             reservation.startDate < ?3 and ?3 <= reservation.endDate)"""
     )
     fun countAllWithOverlappingDates(flatId: String, start: LocalDate, end: LocalDate): Int
+
+    fun findAllByUserId(userId: Long, pageable: Pageable): Page<ReservationEntity>
 }

--- a/src/main/java/pw/react/backend/dao/ReservationRepository.kt
+++ b/src/main/java/pw/react/backend/dao/ReservationRepository.kt
@@ -24,7 +24,7 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
     @Query(
         value = """
             select reservation from ReservationEntity reservation 
-            where reservation.user.id = ?1 and reservation.endDate >= ?2
+            where reservation.user.id = ?1 and reservation.endDate >= ?2 and reservation.cancelled = false
         """
     )
     fun findAllActiveByUserId(userId: Long, today: LocalDate, pageable: Pageable): Page<ReservationEntity>
@@ -32,8 +32,16 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
     @Query(
         value = """
             select reservation from ReservationEntity reservation
-            where reservation.user.id = ?1 and reservation.endDate < ?2
+            where reservation.user.id = ?1 and reservation.endDate < ?2 and reservation.cancelled = false
         """
     )
     fun findAllPassedByUserId(userId: Long, today: LocalDate, pageable: Pageable): Page<ReservationEntity>
+
+    @Query(
+        value = """
+            select reservation from ReservationEntity reservation 
+            where reservation.user.id = ?1 and reservation.cancelled = true
+        """
+    )
+    fun findAllCancelledByUserId(userId: Long, pageable: Pageable): Page<ReservationEntity>
 }

--- a/src/main/java/pw/react/backend/dao/ReservationRepository.kt
+++ b/src/main/java/pw/react/backend/dao/ReservationRepository.kt
@@ -19,12 +19,13 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
     )
     fun countAllWithOverlappingDates(flatId: String, start: LocalDate, end: LocalDate): Int
 
-    fun findAllByUserId(userId: Long, pageable: Pageable): Page<ReservationEntity>
+    fun findAllByUserIdOrderByStartDateAsc(userId: Long, pageable: Pageable): Page<ReservationEntity>
 
     @Query(
         value = """
             select reservation from ReservationEntity reservation 
             where reservation.user.id = ?1 and reservation.endDate >= ?2 and reservation.cancelled = false
+            order by reservation.startDate asc
         """
     )
     fun findAllActiveByUserId(userId: Long, today: LocalDate, pageable: Pageable): Page<ReservationEntity>
@@ -33,6 +34,7 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
         value = """
             select reservation from ReservationEntity reservation
             where reservation.user.id = ?1 and reservation.endDate < ?2 and reservation.cancelled = false
+            order by reservation.startDate asc
         """
     )
     fun findAllPassedByUserId(userId: Long, today: LocalDate, pageable: Pageable): Page<ReservationEntity>
@@ -41,6 +43,7 @@ interface ReservationRepository : JpaRepository<ReservationEntity, Long> {
         value = """
             select reservation from ReservationEntity reservation 
             where reservation.user.id = ?1 and reservation.cancelled = true
+            order by reservation.startDate asc
         """
     )
     fun findAllCancelledByUserId(userId: Long, pageable: Pageable): Page<ReservationEntity>

--- a/src/main/java/pw/react/backend/models/domain/Reservation.kt
+++ b/src/main/java/pw/react/backend/models/domain/Reservation.kt
@@ -42,3 +42,10 @@ fun ReservationEntity.toDomain() = Reservation(
     specialRequests = specialRequests,
     id = id
 )
+
+sealed interface ReservationFilter {
+    data object All : ReservationFilter
+    data object Active : ReservationFilter
+    data object Passed : ReservationFilter
+    data object Cancelled : ReservationFilter
+}

--- a/src/main/java/pw/react/backend/models/domain/Reservation.kt
+++ b/src/main/java/pw/react/backend/models/domain/Reservation.kt
@@ -16,6 +16,7 @@ data class Reservation(
     val children: Int,
     val pets: Int,
     val specialRequests: String? = null,
+    val cancelled: Boolean = false,
     val id: Long? = null,
 )
 
@@ -40,6 +41,7 @@ fun ReservationEntity.toDomain() = Reservation(
     children = children,
     pets = pets,
     specialRequests = specialRequests,
+    cancelled = cancelled,
     id = id
 )
 

--- a/src/main/java/pw/react/backend/models/entity/ReservationEntity.kt
+++ b/src/main/java/pw/react/backend/models/entity/ReservationEntity.kt
@@ -26,6 +26,7 @@ class ReservationEntity(
     val children: Int,
     val pets: Int = 0,
     val specialRequests: String? = null,
+    val cancelled: Boolean = false,
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
 )

--- a/src/main/java/pw/react/backend/services/FlatPriceService.kt
+++ b/src/main/java/pw/react/backend/services/FlatPriceService.kt
@@ -1,8 +1,16 @@
 package pw.react.backend.services
 
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.minus
 import pw.react.backend.dao.FlatPriceRepository
 
 class FlatPriceService(private val flatPriceRepository: FlatPriceRepository) {
 
     fun getPriceByFlatId(flatId: String) = flatPriceRepository.getPriceEntityByFlatId(flatId).priceDollars
+
+    fun getPriceByFlatId(flatId: String, start: LocalDate, end: LocalDate): Double {
+        val pricePerNight = getPriceByFlatId(flatId)
+        val nights = (end - start).days - 1
+        return pricePerNight * nights
+    }
 }

--- a/src/main/java/pw/react/backend/services/FlatService.kt
+++ b/src/main/java/pw/react/backend/services/FlatService.kt
@@ -11,6 +11,7 @@ import pw.react.backend.models.domain.toDomain
 import pw.react.backend.models.entity.AddressEntity
 import pw.react.backend.models.entity.FlatEntity
 import pw.react.backend.models.entity.ReservationEntity
+import kotlin.jvm.optionals.getOrNull
 
 class FlatService(
     private val flatEntityRepository: FlatEntityRepository,
@@ -23,23 +24,27 @@ class FlatService(
         val pageable = PageRequest.of(flatQuery.page, flatQuery.pageSize)
         return flatEntityRepository
             .findAll(flatSpecification(flatQuery), pageable)
-            .map {
-                val flatId = it.id!!
-                Flat(
-                    id = flatId,
-                    title = it.title,
-                    description = it.description,
-                    thumbnailUrl = imageService.getThumbnailUriByFlatId(flatId),
-                    area = it.area,
-                    bedrooms = it.bedrooms,
-                    bathrooms = it.bathrooms,
-                    capacity = it.capacity,
-                    type = it.type,
-                    address = it.address.toDomain(),
-                    rating = reviewService.getRatingByFlatId(flatId),
-                    pricePerNight = priceService.getPriceByFlatId(flatId)
-                )
-            }
+            .map { it.toDomain() }
+    }
+
+    fun findById(flatId: String): Flat? = flatEntityRepository.findById(flatId).getOrNull()?.toDomain()
+
+    private fun FlatEntity.toDomain(): Flat {
+        val flatId = id!!
+        return Flat(
+            id = flatId,
+            title = title,
+            description = description,
+            thumbnailUrl = imageService.getThumbnailUriByFlatId(flatId),
+            area = area,
+            bedrooms = bedrooms,
+            bathrooms = bathrooms,
+            capacity = capacity,
+            type = type,
+            address = address.toDomain(),
+            rating = reviewService.getRatingByFlatId(flatId),
+            pricePerNight = priceService.getPriceByFlatId(flatId)
+        )
     }
 
     private fun flatSpecification(flatQuery: FlatQuery) = roomsSpecification(flatQuery)

--- a/src/main/java/pw/react/backend/services/ReservationService.kt
+++ b/src/main/java/pw/react/backend/services/ReservationService.kt
@@ -58,7 +58,7 @@ class ReservationService(
                 pageable = pageRequest
             )
 
-            is ReservationFilter.Cancelled -> Page.empty()
+            is ReservationFilter.Cancelled -> reservationRepository.findAllCancelledByUserId(userId, pageRequest)
         }.map(ReservationEntity::toDomain)
     }
 

--- a/src/main/java/pw/react/backend/services/ReservationService.kt
+++ b/src/main/java/pw/react/backend/services/ReservationService.kt
@@ -11,6 +11,7 @@ import pw.react.backend.dao.ReservationRepository
 import pw.react.backend.dao.UserRepository
 import pw.react.backend.exceptions.ReservationException
 import pw.react.backend.models.domain.Reservation
+import pw.react.backend.models.domain.ReservationFilter
 import pw.react.backend.models.domain.toDomain
 import pw.react.backend.models.domain.toEntity
 import pw.react.backend.models.entity.ReservationEntity
@@ -33,11 +34,18 @@ class ReservationService(
         return reservationRepository.save(reservationEntity).toDomain()
     }
 
-    fun getReservations(userId: Long, page: Int, pageSize: Int): Page<Reservation> {
+    fun getReservations(
+        userId: Long,
+        page: Int,
+        pageSize: Int,
+        filter: ReservationFilter = ReservationFilter.All
+    ): Page<Reservation> {
         require(page >= 0) { "page must not be negative" }
         require(pageSize > 0) { "page must be positive" }
-        return reservationRepository.findAllByUserId(userId, PageRequest.of(page, pageSize))
-            .map(ReservationEntity::toDomain)
+        return when (filter) {
+            is ReservationFilter.All -> reservationRepository.findAllByUserId(userId, PageRequest.of(page, pageSize))
+            else -> Page.empty()
+        }.map(ReservationEntity::toDomain)
     }
 
     private fun canReserveFlat(flatId: String, startDate: LocalDate, endDate: LocalDate): Boolean {

--- a/src/main/java/pw/react/backend/services/ReservationService.kt
+++ b/src/main/java/pw/react/backend/services/ReservationService.kt
@@ -4,6 +4,8 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toLocalDateTime
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import pw.react.backend.dao.FlatEntityRepository
 import pw.react.backend.dao.ReservationRepository
 import pw.react.backend.dao.UserRepository
@@ -11,6 +13,7 @@ import pw.react.backend.exceptions.ReservationException
 import pw.react.backend.models.domain.Reservation
 import pw.react.backend.models.domain.toDomain
 import pw.react.backend.models.domain.toEntity
+import pw.react.backend.models.entity.ReservationEntity
 import pw.react.backend.utils.TimeProvider
 
 class ReservationService(
@@ -28,6 +31,13 @@ class ReservationService(
             flatEntity = flatRepository.findById(reservation.flatId).get()
         )
         return reservationRepository.save(reservationEntity).toDomain()
+    }
+
+    fun getReservations(userId: Long, page: Int, pageSize: Int): Page<Reservation> {
+        require(page >= 0) { "page must not be negative" }
+        require(pageSize > 0) { "page must be positive" }
+        return reservationRepository.findAllByUserId(userId, PageRequest.of(page, pageSize))
+            .map(ReservationEntity::toDomain)
     }
 
     private fun canReserveFlat(flatId: String, startDate: LocalDate, endDate: LocalDate): Boolean {

--- a/src/main/java/pw/react/backend/services/ReservationService.kt
+++ b/src/main/java/pw/react/backend/services/ReservationService.kt
@@ -45,7 +45,7 @@ class ReservationService(
         require(pageSize > 0) { "page must be positive" }
         val pageRequest = PageRequest.of(page, pageSize)
         return when (filter) {
-            is ReservationFilter.All -> reservationRepository.findAllByUserId(userId, pageRequest)
+            is ReservationFilter.All -> reservationRepository.findAllByUserIdOrderByStartDateAsc(userId, pageRequest)
             is ReservationFilter.Active -> reservationRepository.findAllActiveByUserId(
                 userId = userId,
                 today = timeProvider().toJavaLocalDate(),

--- a/src/main/java/pw/react/backend/services/ReservationService.kt
+++ b/src/main/java/pw/react/backend/services/ReservationService.kt
@@ -58,7 +58,7 @@ class ReservationService(
                 pageable = pageRequest
             )
 
-            else -> Page.empty()
+            is ReservationFilter.Cancelled -> Page.empty()
         }.map(ReservationEntity::toDomain)
     }
 

--- a/src/main/java/pw/react/backend/web/UserReservationDto.kt
+++ b/src/main/java/pw/react/backend/web/UserReservationDto.kt
@@ -1,0 +1,16 @@
+package pw.react.backend.web
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserReservationDto(
+    val flatId: String,
+    val reservationId: Long,
+    val title: String,
+    val thumbnailUrl: String,
+    val city: String,
+    val country: String,
+    val startDate: String,
+    val endDate: String,
+    val totalPrice: Double,
+)

--- a/src/main/resources/sql/setup.sql
+++ b/src/main/resources/sql/setup.sql
@@ -82,13 +82,13 @@ values ('1', 1000, 5, 'Very nice place to stay. I had a great time there.', '202
        ('2', 1001, 2, 'I did not like it there.', '2023-01-01'),
        ('2', 1002, 1, 'Awful.', '2023-01-08');
 
-replace into reservation_entity (id, start_date, end_date, adults, children, pets, special_requests, flat_entity_id,
+replace into reservation_entity (id, start_date, end_date, adults, children, pets, special_requests, cancelled, flat_entity_id,
                                  user_entity_id)
-values (1, '2024-01-01', '2024-01-07', 1, 0, 0, 'Comfy pillow', '2', 1002),
-       (2, '2025-01-01', '2025-01-03', 2, 0, 1, 'Water for my cat pls', '2', 1000),
-       (3, '2025-01-10', '2025-01-13', 2, 0, 1, 'Moar water!', '2', 1000),
-       (4, '2025-01-14', '2025-01-18', 2, 0, 0, null, '1', 1000),
-       (5, '2025-01-21', '2025-01-27', 2, 0, 0, 'Roses', '1', 1000)
+values (1, '2024-01-01', '2024-01-07', 1, 0, 0, 'Comfy pillow', false, '2', 1002),
+       (2, '2025-01-01', '2025-01-03', 2, 0, 1, 'Water for my cat pls', false, '2', 1000),
+       (3, '2025-01-10', '2025-01-13', 2, 0, 1, 'Moar water!', true, '2', 1000),
+       (4, '2025-01-14', '2025-01-18', 2, 0, 0, null, false, '1', 1000),
+       (5, '2025-01-21', '2025-01-27', 2, 0, 0, 'Roses', false, '1', 1000)
 
 
 

--- a/src/test/kotlin/pw/react/backend/controller/ReservationControllerTest.kt
+++ b/src/test/kotlin/pw/react/backend/controller/ReservationControllerTest.kt
@@ -2,12 +2,14 @@ package pw.react.backend.controller
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.data.domain.PageImpl
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
@@ -15,18 +17,25 @@ import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfig
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.web.WebAppConfiguration
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import pw.react.backend.exceptions.ReservationException
+import pw.react.backend.models.domain.ReservationFilter
 import pw.react.backend.security.jwt.services.JwtTokenService
+import pw.react.backend.services.FlatPriceService
+import pw.react.backend.services.FlatService
 import pw.react.backend.services.ReservationService
 import pw.react.backend.services.UserService
+import pw.react.backend.stubs.stubFlat
 import pw.react.backend.stubs.stubReservation
 import pw.react.backend.stubs.stubReservationDto
 import pw.react.backend.stubs.stubUser
+import pw.react.backend.web.PageDto
 import pw.react.backend.web.ReservationDto
+import pw.react.backend.web.UserReservationDto
 
 @WebMvcTest(controllers = [ReservationController::class])
 @ContextConfiguration
@@ -41,6 +50,12 @@ class ReservationControllerTest {
 
     @MockkBean
     private lateinit var userService: UserService
+
+    @MockkBean
+    private lateinit var flatPriceService: FlatPriceService
+
+    @MockkBean
+    private lateinit var flatService: FlatService
 
     @Autowired
     private lateinit var context: WebApplicationContext
@@ -102,6 +117,71 @@ class ReservationControllerTest {
         }
     }
 
+    @Test
+    @WithMockUser
+    fun `Responds with NotFound if user from token was not found`() {
+        every { userService.findUserByEmail(any()) } returns null
+        webMvc.getReservations(page = 0, pageSize = 10)
+            .andExpect {
+                status { isNotFound() }
+            }
+    }
+
+    @Test
+    @WithMockUser
+    fun `Responds with BadRequest if filter is not valid`() {
+        webMvc.getReservations(page = 0, pageSize = 10, filter = "invalid-filter")
+            .andExpect {
+                status { isBadRequest() }
+            }
+    }
+
+    @Test
+    @WithMockUser
+    fun `Responds with UnprocessableEntity if flat from reservation was not found`() {
+        every { reservationService.getReservations(1, 0, 10, ReservationFilter.All) } returns PageImpl(
+            listOf(
+                stubReservation(1, flatId = "1"),
+                stubReservation(1, flatId = "2"),
+            )
+        )
+        every { flatService.findById("1") } returns null
+        webMvc.getReservations(page = 0, pageSize = 10)
+            .andExpect {
+                status { isUnprocessableEntity() }
+            }
+    }
+
+    @Test
+    @WithMockUser
+    fun `Returns correct reservations`() {
+        every { reservationService.getReservations(1, 0, 10, ReservationFilter.All) } returns PageImpl(
+            listOf(stubReservation(1, flatId = "1", id = 123))
+        )
+        every { flatService.findById("1") } returns stubFlat(id = "1")
+        every { flatPriceService.getPriceByFlatId("1", LocalDate(2023, 1, 1), LocalDate(2023, 1, 10)) } returns 800.0
+        val expectedDto = PageDto(
+            data = listOf(
+                UserReservationDto(
+                    flatId = "1",
+                    reservationId = 123,
+                    title = "Flat 1",
+                    thumbnailUrl = "image://flat/1",
+                    city = "Warsaw",
+                    country = "Poland",
+                    startDate = "2023-01-01",
+                    endDate = "2023-01-10",
+                    totalPrice = 800.0
+                )
+            ),
+            last = true
+        )
+        webMvc.getReservations(page = 0, pageSize = 10)
+            .andExpect {
+                content { json(Json.encodeToString(expectedDto)) }
+            }
+    }
+
     private fun MockMvc.postReservation(dto: ReservationDto? = null) = post("/reservation") {
         with(csrf())
         header("Authorization", "Bearer jwt")
@@ -110,4 +190,12 @@ class ReservationControllerTest {
             content = Json.encodeToString(dto)
         }
     }
+
+    private fun MockMvc.getReservations(page: Int, pageSize: Int, filter: String? = null) =
+        get("/reservations") {
+            header("Authorization", "Bearer jwt")
+            param("page", page.toString())
+            param("pageSize", pageSize.toString())
+            filter?.let { param("filter", it) }
+        }
 }

--- a/src/test/kotlin/pw/react/backend/services/FlatPriceServiceTest.kt
+++ b/src/test/kotlin/pw/react/backend/services/FlatPriceServiceTest.kt
@@ -1,0 +1,23 @@
+package pw.react.backend.services
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.Test
+import pw.react.backend.dao.FlatPriceRepository
+import pw.react.backend.stubs.stubPriceEntity
+
+class FlatPriceServiceTest {
+
+    private val flatPriceRepository = mockk<FlatPriceRepository>().also {
+        every { it.getPriceEntityByFlatId("1") } returns stubPriceEntity(priceDollars = 100.0)
+    }
+    private val flatPriceService = FlatPriceService(flatPriceRepository)
+
+    @Test
+    fun `Return correct price for nights between start and end dates`() {
+        val priceFor8Nights = flatPriceService.getPriceByFlatId("1", LocalDate(2023, 1, 1), LocalDate(2023, 1, 10))
+        priceFor8Nights shouldBe 800.0
+    }
+}

--- a/src/test/kotlin/pw/react/backend/stubs/StubReservation.kt
+++ b/src/test/kotlin/pw/react/backend/stubs/StubReservation.kt
@@ -17,6 +17,7 @@ fun stubReservationEntity(
     children: Int = 1,
     pets: Int = 0,
     specialRequests: String? = "Pink pillow",
+    cancelled: Boolean = false,
     id: Long? = null
 ) = ReservationEntity(
     user = user,
@@ -27,6 +28,7 @@ fun stubReservationEntity(
     children = children,
     pets = pets,
     specialRequests = specialRequests,
+    cancelled = cancelled,
     id = id
 )
 
@@ -39,8 +41,9 @@ fun stubReservation(
     children: Int = 1,
     pets: Int = 0,
     specialRequests: String? = "Pink pillow",
+    cancelled: Boolean = false,
     id: Long? = null
-) = Reservation(userId, flatId, startDate, endDate, adults, children, pets, specialRequests, id)
+) = Reservation(userId, flatId, startDate, endDate, adults, children, pets, specialRequests, cancelled, id)
 
 fun stubReservationDto(
     flatId: String,


### PR DESCRIPTION
The goal of this endpoint was to implement endpoint for getting pageable list of user's reservations. The endpoint has an optional filter that defines type of returned reservations. Handled filters are: `active`, `passed`, `passed` and `all`. No passed filter is equivalent to passing `all` filter